### PR TITLE
Add cache revalidation for collections

### DIFF
--- a/backend/src/subscribers/collection-updated.ts
+++ b/backend/src/subscribers/collection-updated.ts
@@ -1,0 +1,18 @@
+import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
+
+/**
+ * Triggers storefront cache revalidation when collections or related products are updated.
+ */
+export default async function collectionUpdatedSubscriber({ container }: SubscriberArgs) {
+  const url = process.env.STOREFRONT_URL || "http://localhost:3000"
+
+  try {
+    await fetch(`${url}/api/revalidate/collections`, { method: "POST" })
+  } catch (err) {
+    container.logger?.error(`Failed to revalidate collections tag: ${err}`)
+  }
+}
+
+export const config: SubscriberConfig = {
+  event: ["product.updated", "collection.updated"],
+}

--- a/storefront/src/app/api/revalidate/collections/route.ts
+++ b/storefront/src/app/api/revalidate/collections/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server"
+import { revalidateTag } from "next/cache"
+
+export async function POST() {
+  revalidateTag("collections")
+  return NextResponse.json({ revalidated: true })
+}


### PR DESCRIPTION
## Summary
- add API route to revalidate the `collections` cache tag
- trigger that API from a new backend subscriber when collections or products are updated

## Testing
- `true`