### PR TITLE
Add STOREFRONT_URL config

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Video instructions: https://youtu.be/PPxenu7IjGM
 - `cd /backend`
 - `pnpm install` or `npm i`
 - Rename `.env.template` ->  `.env`
+- Set `STOREFRONT_URL` in `.env` to your live storefront URL
 - To connect to your online database from your local machine, copy the `DATABASE_URL` value auto-generated on Railway and add it to your `.env` file.
   - If connecting to a new database, for example a local one, run `pnpm ib` or `npm run ib` to seed the database.
 - `pnpm dev` or `npm run dev`

--- a/backend/.env.template
+++ b/backend/.env.template
@@ -26,3 +26,6 @@ SENDGRID_FROM=
 # MEILISEARCH_HOST=your-meilisearch-host # e.g. http://localhost:7700
 # MEILISEARCH_MASTER_KEY=your-master-key # Required if MEILISEARCH_ADMIN_KEY is not set
 # MEILISEARCH_ADMIN_KEY=your-admin-key # Optional - if not set, will be fetched using master key
+
+# Frontend URL used for revalidation. Set to your live storefront URL
+STOREFRONT_URL=http://localhost:3000

--- a/backend/src/lib/constants.ts
+++ b/backend/src/lib/constants.ts
@@ -15,6 +15,11 @@ export const IS_DEV = process.env.NODE_ENV === 'development'
 export const BACKEND_URL = process.env.BACKEND_PUBLIC_URL ?? process.env.RAILWAY_PUBLIC_DOMAIN_VALUE ?? 'http://localhost:9000'
 
 /**
+ * Public URL for the storefront
+ */
+export const STOREFRONT_URL = process.env.STOREFRONT_URL ?? 'http://localhost:3000'
+
+/**
  * Database URL for Postgres instance used by the backend
  */
 export const DATABASE_URL = assertValue(

--- a/backend/src/subscribers/collection-updated.ts
+++ b/backend/src/subscribers/collection-updated.ts
@@ -1,10 +1,11 @@
 import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
+import { STOREFRONT_URL } from "../lib/constants"
 
 /**
  * Triggers storefront cache revalidation when collections or related products are updated.
  */
 export default async function collectionUpdatedSubscriber({ container }: SubscriberArgs) {
-  const url = process.env.STOREFRONT_URL || "http://localhost:3000"
+  const url = STOREFRONT_URL
 
   try {
     await fetch(`${url}/api/revalidate/collections`, { method: "POST" })


### PR DESCRIPTION
## Summary
- document STOREFRONT_URL usage in backend `.env`
- expose `STOREFRONT_URL` constant
- use the constant in the collection-updated subscriber
- mention STOREFRONT_URL in backend setup instructions

## Testing
- `npm test --workspaces` *(fails: could not read package.json)*
- `cd backend && npm test` *(fails: Missing script)*
- `cd ../storefront && npm test` *(fails: Missing script)*
- `npm run lint` in storefront *(fails: next not found)*